### PR TITLE
Add missing DB initialization line

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,7 @@
     python manage.py db init
     python manage.py db migrate
     python manage.py db upgrade
+    python manage.py init_data
     ```
 
 7. Configure uWSGI and Nginx


### PR DESCRIPTION
There was a line in a [blog post][1] that was missing from the
INSTALL.md document in the repo. This makes the repo document accurate
for initializing the first user account.

[1]: https://unifispot.com/blog/blog/2016/03/install-unifispot-poppet-ubuntu-14-04/